### PR TITLE
deps: Extract type definitions for npm-dependants

### DIFF
--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -1,0 +1,5 @@
+# Upstream contributions
+
+To support the functionality of this package, the following upstream contributions have been contributed back as of today:
+
+- [types@/npm-dependants](https://www.npmjs.com/package/@types/npm-dependants)

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "devDependencies": {
         "@types/got": "^9.6.11",
         "@types/jest": "^26.0.23",
+        "@types/npm-dependants": "^2.1.0",
         "@types/rimraf": "^3.0.0",
         "jest": "^26.6.3",
         "read-package-json": "^3.0.1",

--- a/src/@types/npm-dependants.d.ts
+++ b/src/@types/npm-dependants.d.ts
@@ -1,4 +1,0 @@
-declare module 'npm-dependants' {
-    /** Get dependants of a module on npm. */
-    export default function npmDependants(name: string): AsyncIterable<string>
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -773,6 +773,13 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
+"@types/npm-dependants@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/npm-dependants/-/npm-dependants-2.1.0.tgz#a50106ba69c24f6753210da0a72a667919389f7e"
+  integrity sha512-h71GDCGjJeXr6VLWG1tXhO96kwPKmhVPqOMVF5+U7NZtjzHumT7bRzYQJHFhK6RBggFScbW/6cDPsw7REq/R+w==
+  dependencies:
+    "@types/node" "*"
+
 "@types/prettier@^2.0.0":
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.2.3.tgz#ef65165aea2924c9359205bf748865b8881753c0"


### PR DESCRIPTION
@types/npm-dependants is now a separate npm package. See: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/52734