### PR TITLE
Add smoke test for CLI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           node-version: '14'
       - run: yarn install
-      - run: ./bin/run.js help
+      - run: ./script/test-cli.sh
       - run: yarn test
         env:
           GITHUB_OAUTH_TOKEN: ${{ github.token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           node-version: '14'
       - run: yarn install
-      - run: ./script/test-cli.sh
+      - run: ./scripts/test-cli.sh
       - run: yarn test
         env:
           GITHUB_OAUTH_TOKEN: ${{ github.token }}

--- a/scripts/test-cli.sh
+++ b/scripts/test-cli.sh
@@ -6,7 +6,8 @@ fail() {
     exit 1
 }
 
-output="$(./bin/run.js help | tee /dev/tty)"
+output="$(./bin/run.js help)"
+echo "$output"
 
 commands="$(echo "$output" | sed -n '/^COMMANDS$/,$p' | sed -n '/^  /p')"
 number_of_commands="$(echo "$commands" | wc -l)"

--- a/scripts/test-cli.sh
+++ b/scripts/test-cli.sh
@@ -12,4 +12,4 @@ echo "$output"
 commands="$(echo "$output" | sed -n '/^COMMANDS$/,$p' | sed -n '/^  /p')"
 number_of_commands="$(echo "$commands" | wc -l)"
 
-(( $number_of_commands > 10 )) || fail "Not enough commands provided"
+(( $number_of_commands > 1 )) || fail "Not enough commands provided"

--- a/scripts/test-cli.sh
+++ b/scripts/test-cli.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/bash
+set -e
+
+fail() {
+    >&2 echo "$1"
+    exit 1
+}
+
+output="$(./bin/run.js help | tee /dev/tty)"
+
+commands="$(echo "$output" | sed -n '/^COMMANDS$/,$p' | sed -n '/^  /p')"
+number_of_commands="$(echo "$commands" | wc -l)"
+
+(( $number_of_commands > 10 )) || fail "Not enough commands provided"


### PR DESCRIPTION
Due to repeated breakdowns of the oclif functionality in the past, presumably caused by faulty module import configurations, we introduce a simple smoke test that will make the CI fail if the CLI does not provide at least 2 commands. See also 74fe4be.